### PR TITLE
Example of usage with Taurus BZT

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,15 +189,15 @@ data "aws_ami" "my_image" {
 The [C5](https://aws.amazon.com/pt/ec2/instance-types/c5/) family of instances is a good choice for the load test.
 
 
-|Modelo|vCPU|Memória (GiB)|Armazenamento de instâncias (GiB)|Largura de banda de rede (Gbps)|
+|Model|vCPU|Mem (GiB)|Storage (GiB)|Network Band. (Gbps)|
 |:---:|:---:|:---:|:---:|:---:|
-|c5n.large| 2 | 5.25	| Somente EBS | Até 25 Até 4.750| 
-|c5n.xlarge| 4 | 10.5	| Somente EBS | Até 25	Até 4.750| 
-|c5n.2xlarge| 8 | 21	| Somente EBS | Até 25	Até 4.750| 
-|c5n.4xlarge| 16 | 42	| Somente EBS | Até 25	4.750| 
-|c5n.9xlarge| 36 | 96   | Somente EBS | 50	9.500| 
-|c5n.18xlarge| 72 | 192	| Somente EBS | 100	19.000| 
-|c5n.metal| 72 | 192	| Somente EBS | 100	19.000| 
+|c5n.large| 2 | 5.25	| EBS | 25 -> 4.750| 
+|c5n.xlarge| 4 | 10.5	| EBS | 25	-> 4.750| 
+|c5n.2xlarge| 8 | 21	| EBS | 25	-> 4.750| 
+|c5n.4xlarge| 16 | 42	| EBS | 25	4.750| 
+|c5n.9xlarge| 36 | 96   | EBS | 50	9.500| 
+|c5n.18xlarge| 72 | 192	| EBS | 100	19.000| 
+|c5n.metal| 72 | 192	| EBS | 100	19.000| 
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -9,15 +9,16 @@ This module proposes a simple and uncomplicated way to run your load tests creat
 ## Basic usage with JMeter
 
 ```hcl
-module "loadtest" {
+module "loadtest-distribuited" {
 
     source  = "marcosborges/loadtest-distribuited/aws"
-  
+
     name = "nome-da-implantacao"
     executor = "jmeter"
-    loadtest_dir_source = "./assets"
-    loadtest_entrypoint = "jmeter -n -t jmeter/basic.jmx -R \"{NODES_IPS}\" *.jmx"
+    loadtest_dir_source = "examples/plan/"
     nodes_size = 2
+    
+    loadtest_entrypoint = "jmeter -n -t jmeter/basic.jmx  -R \"{NODES_IPS}\" -l /var/logs/loadtest -e -o /var/www/html -Dnashorn.args=--no-deprecation-warning -Dserver.rmi.ssl.disable=true "
 
     subnet_id = data.aws_subnet.current.id
 }
@@ -35,8 +36,6 @@ data "aws_subnet" "current" {
 
 ![bp](https://github.com/marcosborges/terraform-aws-loadtest-distribuited/raw/master/assets/jmeter-dashboard.png) 
 
-
-
 ---
 
 ## Basic usage with Taurus
@@ -44,15 +43,16 @@ data "aws_subnet" "current" {
 In its basic use it is necessary to provide information about which network will be used, where are your test plan scripts and finally define the number of nodes needed to carry out the desired load.
 
 ```hcl
-module "loadtest" {
+module "loadtest-distribuited" {
 
     source  = "marcosborges/loadtest-distribuited/aws"
-  
+
     name = "nome-da-implantacao"
-    executor = "bzt"
-    loadtest_dir_source = "./load-test-plan"
-    loadtest_entrypoint = "bzt -q -o execution.0.distributed=\"{NODES_IPS}\" *.yml"
+    executor = "jmeter"
+    loadtest_dir_source = "examples/plan/"
     nodes_size = 2
+    
+    loadtest_entrypoint = "bzt -q -o execution.0.distributed=\"{NODES_IPS}\" taurus/basic.yml"
 
     subnet_id = data.aws_subnet.current.id
 }
@@ -84,22 +84,25 @@ The module also provides advanced settings.
 ```hcl
 module "loadtest" {
 
+
     source  = "marcosborges/loadtest-distribuited/aws"
-  
-    subnet_id = data.aws_subnet.current.id
 
     name = "nome-da-implantacao"
     executor = "bzt"
-    loadtest_dir_source = "./assets"
+    loadtest_dir_source = "examples/plan/"
+
     loadtest_dir_destination = "/loadtest"
-    loadtest_entrypoint = "bzt -q -o execution.0.distributed=\"{NODES_IPS}\" *.yml"
+    loadtest_entrypoint = "bzt -q -o execution.0.distributed=\"{NODES_IPS}\" taurus/basic.yml"
     nodes_size = 3
 
+    
+    subnet_id = data.aws_subnet.current.id
+    
     #AUTO SPLIT
     split_data_mass_between_nodes = {
         enable = true
         data_mass_filenames = [
-            "../plan/data/data.csv"
+            "data/users.csv"
         ]
     }
 
@@ -179,16 +182,22 @@ data "aws_ami" "my_image" {
 }
 
 ```
-
 ---
 
+## Sugestion
 
-## Defaults
-
-**Instance type:**  https://aws.amazon.com/pt/ec2/instance-types/c5/
-
+The [C5](https://aws.amazon.com/pt/ec2/instance-types/c5/) family of instances is a good choice for the load test.
 
 
+|Modelo|vCPU|Memória (GiB)|Armazenamento de instâncias (GiB)|Largura de banda de rede (Gbps)|
+|:---:|:---:|:---:|:---:|:---:|
+|c5n.large| 2 | 5.25	| Somente EBS | Até 25 Até 4.750| 
+|c5n.xlarge| 4 | 10.5	| Somente EBS | Até 25	Até 4.750| 
+|c5n.2xlarge| 8 | 21	| Somente EBS | Até 25	Até 4.750| 
+|c5n.4xlarge| 16 | 42	| Somente EBS | Até 25	4.750| 
+|c5n.9xlarge| 36 | 96   | Somente EBS | 50	9.500| 
+|c5n.18xlarge| 72 | 192	| Somente EBS | 100	19.000| 
+|c5n.metal| 72 | 192	| Somente EBS | 100	19.000| 
 
 ---
 

--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -8,7 +8,7 @@ module "loadtest-distribuited" {
     source = "../../"
     #source  = "marcosborges/loadtest-distribuited/aws"
 
-    name = "nome-da-implantacao"
+    name = "nome-da-implantacao-basic"
     executor = "jmeter"
     loadtest_dir_source = "../plan/"
     nodes_size = 2

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -2,9 +2,8 @@ module "loadtest" {
 
     source = "../../"
     #source  = "marcosborges/loadtest-distribuited/aws"
-    #version = "1.0.0"
 
-    name = "nome-da-implantacao"
+    name = "nome-da-implantacao-basic"
     executor = var.executor #"jmeter"
     loadtest_dir_source = "../plan/"
     nodes_size = 2

--- a/examples/plan/taurus/basic.yml
+++ b/examples/plan/taurus/basic.yml
@@ -1,18 +1,37 @@
 execution:
-- concurrency: 10
-  ramp-up: 1m
-  hold-for: 5m
-  scenario: quick-test
+  - concurrency: 10
+    ramp-up: 1m
+    hold-for: 5m
+    scenario: quick-test
 
 scenarios:
   quick-test:
+    #data-sources: 
+    #  - path: /loadtest/data/users.csv
+    #    delimiter: ','
+    #    quoted: true
+    #    encoding: "utf-8"
+    #    loop: true
+    #    variable-names: name,email,password
+    #    random-order: false
     requests:
-    
-    - label: Google
-      url: https://google.com
-    
-    - label: Microsoft
-      url: https://microsoft.com
-    
-    - label: Facebook
-      url: https://facebook.com
+      - label: Google
+        url: https://google.com
+      - label: Microsoft
+        url: https://microsoft.com
+      - label: Facebook
+        url: https://facebook.com
+    properties:
+      server.rmi.ssl.disable: true
+
+modules:
+  jmeter:
+    gui: false
+    version: 5.4.1
+    properties:
+      mode: StrippedBatch
+    memory-xmx: 10G
+    cmdline: -l /loadtest/logs -e -o /var/www/html/taurus 
+
+settings:
+ verbose: false

--- a/examples/split-data/README.md
+++ b/examples/split-data/README.md
@@ -15,7 +15,7 @@ module "loadtest" {
 
     source  = "marcosborges/loadtest-distribuited/aws"
     
-    name = "nome-da-implantacao"
+    name = "nome-da-implantacao-spliter"
     executor = "jmeter"
     loadtest_dir_source = "../plan/"
     nodes_size = 2

--- a/examples/split-data/main.tf
+++ b/examples/split-data/main.tf
@@ -3,7 +3,7 @@ module "loadtest" {
     source = "../../"
     #source  = "marcosborges/loadtest-distribuited/aws"
     
-    name = "nome-da-implantacao"
+    name = "nome-da-implantacao-spliter"
     executor = "jmeter"
     loadtest_dir_source = "../plan/"
     nodes_size = 2

--- a/examples/taurus/README.md
+++ b/examples/taurus/README.md
@@ -1,4 +1,4 @@
-# Basic Config:
+# Taurus Basic Configuration
     
 In its basic use it is necessary to provide information about which network will be used, where are your test plan scripts and finally define the number of nodes needed to carry out the desired load.
 
@@ -8,10 +8,10 @@ module "loadtest" {
     source = "../../"
 
     name = "nome-da-implantacao-taurus"
-    executor = "jmeter"
+    executor = "bzt"
     loadtest_dir_source = "../plan/"
-    loadtest_entrypoint = "bzt -q -o execution.0.distributed=\"{NODES_IPS}\" *.yml"
-    nodes_size = 3
+    loadtest_entrypoint = "bzt -q -o execution.0.distributed=\"{NODES_IPS}\" taurus/*.yml"
+    nodes_size = 2
 
     subnet_id = data.aws_subnet.current.id
 }

--- a/examples/taurus/README.md
+++ b/examples/taurus/README.md
@@ -7,9 +7,9 @@ module "loadtest" {
 
     source = "../../"
 
-    name = "nome-da-implantacao"
+    name = "nome-da-implantacao-taurus"
     executor = "jmeter"
-    loadtest_dir_source = "../plan"
+    loadtest_dir_source = "../plan/"
     loadtest_entrypoint = "bzt -q -o execution.0.distributed=\"{NODES_IPS}\" *.yml"
     nodes_size = 3
 

--- a/examples/taurus/main.tf
+++ b/examples/taurus/main.tf
@@ -1,18 +1,15 @@
-provider "aws" {
-    region = "us-east-1"
-}
-
 module "loadtest" {
 
     source = "../../"
 
-    name = "nome-da-implantacao"
-    executor = "jmeter"
-    loadtest_dir_source = "../plan"
-    loadtest_entrypoint = "bzt -q -o execution.0.distributed=\"{NODES_IPS}\" *.yml"
-    nodes_size = 3
+    name = "nome-da-implantacao-taurus"
+    executor = "bzt"
+    loadtest_dir_source = "../plan/"
+    loadtest_entrypoint = "bzt -q -o execution.0.distributed=\"{NODES_IPS}\" taurus/*.yml"
+    nodes_size = 2
 
     subnet_id = data.aws_subnet.current.id
+    ssh_export_pem = false
 }
 
 data "aws_subnet" "current" {

--- a/executor.tf
+++ b/executor.tf
@@ -74,6 +74,7 @@ resource "null_resource" "executor" {
     provisioner "remote-exec" {
         inline = [
             "echo DIR: ${var.loadtest_dir_destination}",
+            "ls -lah ${var.loadtest_dir_destination}",
             "cd ${var.loadtest_dir_destination}",
             "echo ${local.entrypoint}",
             local.entrypoint

--- a/leader.tf
+++ b/leader.tf
@@ -45,9 +45,3 @@ resource "aws_instance" "leader" {
         }
     )
 }
-
-
-resource "null_resource" "push_key_pair_to_leader" {
-    
-    
-}

--- a/slipter.tf
+++ b/slipter.tf
@@ -54,12 +54,12 @@ locals {
 
     # JOIN COMMANDS TO BE EXECUTED BY LEADER
     leader_cmds = concat(
+        ["echo AUTO SPLITER"],
         local.leader_split_cmds, 
         local.leader_ssh_nodes_cleanup_cmds,
         local.leader_scp_cmds
     )
 }
-
 
 resource "null_resource" "spliter_execute_command" {
     


### PR DESCRIPTION
# Taurus Basic Configuration
    
In its basic use it is necessary to provide information about which network will be used, where are your test plan scripts and finally define the number of nodes needed to carry out the desired load.

```hcl
module "loadtest" {

    source = "../../"

    name = "nome-da-implantacao-taurus"
    executor = "bzt"
    loadtest_dir_source = "../plan/"
    loadtest_entrypoint = "bzt -q -o execution.0.distributed=\"{NODES_IPS}\" taurus/*.yml"
    nodes_size = 2

    subnet_id = data.aws_subnet.current.id
}

data "aws_subnet" "current" {
    filter {
        name   = "tag:Name"
        values = ["subnet-prd-a"]
    }
}
```

---
