### PR TITLE
Update Locust version. 2.4.3 doesn't work

### DIFF
--- a/scripts/entrypoint.leader.full.sh.tpl
+++ b/scripts/entrypoint.leader.full.sh.tpl
@@ -14,7 +14,7 @@ export BZT_VERSION="1.16.0"
 sudo pip3 install bzt==$BZT_VERSION
 
 # LOCUST
-export LOCUST_VERSION="2.4.3"
+export LOCUST_VERSION="2.9.0"
 sudo pip3 install locust==$LOCUST_VERSION
 
 # JMETER

--- a/scripts/entrypoint.node.full.sh.tpl
+++ b/scripts/entrypoint.node.full.sh.tpl
@@ -8,7 +8,7 @@ export BZT_VERSION="1.16.0"
 sudo pip3 install bzt==$BZT_VERSION
 
 # LOCUST
-export LOCUST_VERSION="2.4.3"
+export LOCUST_VERSION="2.9.0"
 sudo pip3 install locust==$LOCUST_VERSION
 
 

--- a/scripts/locust.entrypoint.leader.full.sh.tpl
+++ b/scripts/locust.entrypoint.leader.full.sh.tpl
@@ -4,7 +4,7 @@ sudo yum update -y
 sudo yum install -y pcre2-devel.x86_64 python gcc python3-devel tzdata curl unzip bash htop
 
 # LOCUST
-export LOCUST_VERSION="2.4.3"
+export LOCUST_VERSION="2.9.0"
 sudo pip3 install locust==$LOCUST_VERSION
 
 export PRIVATE_IP=$(hostname -I | awk '{print $1}')

--- a/scripts/locust.entrypoint.node.full.sh.tpl
+++ b/scripts/locust.entrypoint.node.full.sh.tpl
@@ -4,7 +4,7 @@ sudo yum update -y
 sudo yum install -y pcre2-devel.x86_64 python gcc python3-devel tzdata curl unzip bash htop
 
 # LOCUST
-export LOCUST_VERSION="2.4.3"
+export LOCUST_VERSION="2.9.0"
 sudo pip3 install locust==$LOCUST_VERSION
 
 export PRIVATE_IP=$(hostname -I | awk '{print $1}')


### PR DESCRIPTION
An old version Locust involves a PyZMQ breaking change due to unlocked version. Locust 2.9.0 fixes this issue by setting a strict version specifier.
Details: https://github.com/locustio/locust/issues/2099