### PR TITLE
chore: Upgrade locust:2.10.1

### DIFF
--- a/scripts/entrypoint.leader.full.sh.tpl
+++ b/scripts/entrypoint.leader.full.sh.tpl
@@ -14,7 +14,7 @@ export BZT_VERSION="1.16.0"
 sudo pip3 install bzt==$BZT_VERSION
 
 # LOCUST
-export LOCUST_VERSION="2.9.0"
+export LOCUST_VERSION="2.10.1"
 sudo pip3 install locust==$LOCUST_VERSION
 
 # JMETER

--- a/scripts/entrypoint.node.full.sh.tpl
+++ b/scripts/entrypoint.node.full.sh.tpl
@@ -8,7 +8,7 @@ export BZT_VERSION="1.16.0"
 sudo pip3 install bzt==$BZT_VERSION
 
 # LOCUST
-export LOCUST_VERSION="2.9.0"
+export LOCUST_VERSION="2.10.1"
 sudo pip3 install locust==$LOCUST_VERSION
 
 

--- a/scripts/locust.entrypoint.leader.full.sh.tpl
+++ b/scripts/locust.entrypoint.leader.full.sh.tpl
@@ -4,7 +4,7 @@ sudo yum update -y
 sudo yum install -y pcre2-devel.x86_64 python gcc python3-devel tzdata curl unzip bash htop
 
 # LOCUST
-export LOCUST_VERSION="2.9.0"
+export LOCUST_VERSION="2.10.1"
 sudo pip3 install locust==$LOCUST_VERSION
 
 export PRIVATE_IP=$(hostname -I | awk '{print $1}')

--- a/scripts/locust.entrypoint.node.full.sh.tpl
+++ b/scripts/locust.entrypoint.node.full.sh.tpl
@@ -4,7 +4,7 @@ sudo yum update -y
 sudo yum install -y pcre2-devel.x86_64 python gcc python3-devel tzdata curl unzip bash htop
 
 # LOCUST
-export LOCUST_VERSION="2.9.0"
+export LOCUST_VERSION="2.10.1"
 sudo pip3 install locust==$LOCUST_VERSION
 
 export PRIVATE_IP=$(hostname -I | awk '{print $1}')


### PR DESCRIPTION
## Motivation

The published version installs locust `2.4.1` which doesn't recognize `test_stopping` event.
```
[ec2-user@ip-10-60-32-61 ~]$ cat /loadtest/locust-leader.out
Traceback (most recent call last):
  File "/usr/local/bin/locust", line 8, in <module>
    sys.exit(main())
  File "/usr/local/lib/python3.7/site-packages/locust/main.py", line 126, in main
    docstring, user_classes, shape_class = load_locustfile(locustfile)
  File "/usr/local/lib/python3.7/site-packages/locust/main.py", line 81, in load_locustfile
    imported = source.load_module()
  File "<frozen importlib._bootstrap_external>", line 407, in _check_name_wrapper
  File "<frozen importlib._bootstrap_external>", line 907, in load_module
  File "<frozen importlib._bootstrap_external>", line 732, in load_module
  File "<frozen importlib._bootstrap>", line 265, in _load_module_shim
  File "<frozen importlib._bootstrap>", line 696, in _load
  File "<frozen importlib._bootstrap>", line 677, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 728, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "test.py", line 21, in <module>
    @events.test_stopping.add_listener
AttributeError: 'Events' object has no attribute 'test_stopping
```

## Checklist
- [x] Add [semantics prefix](https://github.com/marcosborges/terraform-aws-loadtest-distribuited/blob/8b6f595d1b1b482753faf3ef74325ef69b67cc3b/.github/contributing.md#semantic-pull-requests) to your PR or Commits (at least one of your commit groups)
- [x]  CI tests are passing
- [x]  README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-vpc/#doc-generation
- [x]  Run pre-commit hooks pre-commit run -a
