### PR TITLE
Add tags to EBS volumes

### DIFF
--- a/leader.tf
+++ b/leader.tf
@@ -41,6 +41,11 @@ resource "aws_instance" "leader" {
     var.tags,
     var.leader_tags
   )
+
+  volume_tags = merge(
+    var.tags,
+    var.nodes_tags
+  )
 }
 
 

--- a/nodes.tf
+++ b/nodes.tf
@@ -53,6 +53,8 @@ resource "aws_instance" "nodes" {
     var.tags,
     var.nodes_tags
   )
+
+  volume_tags = tags
 }
 
 locals {

--- a/nodes.tf
+++ b/nodes.tf
@@ -54,7 +54,10 @@ resource "aws_instance" "nodes" {
     var.nodes_tags
   )
 
-  volume_tags = tags
+  volume_tags = merge(
+    var.tags,
+    var.nodes_tags
+  )
 }
 
 locals {


### PR DESCRIPTION
On `aws_instance` resource, tags are not applied to its volumes. 
`volume_tags` should be added, too.