### PR TITLE
Upgrade AMI to Amazon Linux 2023

### DIFF
--- a/ami.tf
+++ b/ami.tf
@@ -12,6 +12,6 @@ data "aws_ami" "amazon_linux_2" {
   owners = ["amazon"]
   filter {
     name   = "name"
-    values = ["amzn2-ami-hvm*"]
+    values = ["al2023-ami-2023.*-x86_64"]
   }
 }

--- a/scripts/locust.entrypoint.leader.full.sh.tpl
+++ b/scripts/locust.entrypoint.leader.full.sh.tpl
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 sudo yum update -y
-sudo yum install -y pcre2-devel.x86_64 python gcc python3-devel tzdata curl unzip bash htop
+sudo yum install -y pcre2-devel.x86_64 python gcc python3-devel tzdata curl unzip bash htop python3-pip --skip-broken
 
 # LOCUST
 export LOCUST_VERSION="2.9.0"

--- a/scripts/locust.entrypoint.node.full.sh.tpl
+++ b/scripts/locust.entrypoint.node.full.sh.tpl
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 sudo yum update -y
-sudo yum install -y pcre2-devel.x86_64 python gcc python3-devel tzdata curl unzip bash htop
+sudo yum install -y pcre2-devel.x86_64 python gcc python3-devel tzdata curl unzip bash htop python3-pip --skip-broken
 
 # LOCUST
 export LOCUST_VERSION="2.9.0"


### PR DESCRIPTION
When testing Locust, it seemed to run into a problem where urllib3 wasn't compatible with the installed openssl version. 

The issue was fixed by upgrading from Amazon Linux 2 to Amazon Linux 2023.  Then locust ran successfully.

Generally it's advisable to upgrade the operating system anyway.

Other discoveries:

- python3-pip was missing (in 2023), so added that in the module.
- for some reason when installing curl, it tries to install curl-minimal also, and that causes a conflict. Added the -`-skip-broken` flag to skip over the error. Not a show-stopper.  Another idea is to remove curl from the list entirely because 2023 includes curl already.
