### PR TITLE
Set permissions on .pem file

### DIFF
--- a/security.tf
+++ b/security.tf
@@ -89,7 +89,7 @@ resource "tls_private_key" "loadtest" {
 }
 
 locals {
-  export_pem_cmd = var.ssh_export_pem == true ? "echo '${tls_private_key.loadtest.private_key_pem}' > ${var.name}-loadtest-keypair.pem" : "echo 'key pair export disabled'"
+  export_pem_cmd = var.ssh_export_pem == true ? "echo '${tls_private_key.loadtest.private_key_pem}' > ${var.name}-loadtest-keypair.pem ; chmod 600 ${var.name}-loadtest-keypair.pem" : "echo 'key pair export disabled'"
 }
 
 resource "aws_key_pair" "loadtest" {


### PR DESCRIPTION
If you use an SSH private key to connect to a remote server, the permissions on the private key should be 600.  If permissions are too broad, SSH will refuse to continue. 

This terraform module writes a private ssh key to disk. It should set permissions so the key can be used immediately.

