### PR TITLE
Switch to al2023

### DIFF
--- a/ami.tf
+++ b/ami.tf
@@ -1,9 +1,9 @@
 locals {
-  leader_ami_id = var.leader_ami_id == "" ? data.aws_ami.amazon_linux_2.id : var.leader_ami_id
-  nodes_ami_id  = var.nodes_ami_id == "" ? data.aws_ami.amazon_linux_2.id : var.nodes_ami_id
+  leader_ami_id = var.leader_ami_id == "" ? data.aws_ami.amazon_linux_2023.id : var.leader_ami_id
+  nodes_ami_id  = var.nodes_ami_id == "" ? data.aws_ami.amazon_linux_2023.id : var.nodes_ami_id
 }
 
-data "aws_ami" "amazon_linux_2" {
+data "aws_ami" "amazon_linux_2023" {
   most_recent = true
   filter {
     name   = "owner-alias"
@@ -12,6 +12,6 @@ data "aws_ami" "amazon_linux_2" {
   owners = ["amazon"]
   filter {
     name   = "name"
-    values = ["amzn2-ami-hvm*"]
+    values = ["al2023-ami-*"]
   }
 }

--- a/leader.tf
+++ b/leader.tf
@@ -8,7 +8,10 @@ resource "aws_instance" "leader" {
   monitoring                  = var.leader_monitoring
 
   subnet_id              = var.subnet_id
-  vpc_security_group_ids = [aws_security_group.loadtest.id]
+  vpc_security_groups_ids = concat(
+    [aws_security_group.loadtest.id],  # Default security group ID
+    var.additional_security_groups != null ? var.additional_security_groups : []
+  )
 
   iam_instance_profile = aws_iam_instance_profile.loadtest.name
   user_data_base64     = local.setup_leader_base64

--- a/leader.tf
+++ b/leader.tf
@@ -8,7 +8,7 @@ resource "aws_instance" "leader" {
   monitoring                  = var.leader_monitoring
 
   subnet_id              = var.subnet_id
-  vpc_security_groups_ids = concat(
+  vpc_security_group_ids = concat(
     [aws_security_group.loadtest.id],  # Default security group ID
     var.additional_security_groups != null ? var.additional_security_groups : []
   )

--- a/nodes.tf
+++ b/nodes.tf
@@ -9,7 +9,10 @@ resource "aws_instance" "nodes" {
   monitoring                  = var.nodes_monitoring
 
   subnet_id              = var.subnet_id
-  vpc_security_group_ids = [aws_security_group.loadtest.id]
+  vpc_security_groups_ids = concat(
+    [aws_security_group.loadtest.id],  # Default security group ID
+    var.additional_security_groups != null ? var.additional_security_groups : []
+  )
 
   iam_instance_profile = aws_iam_instance_profile.loadtest.name
   user_data_base64     = local.setup_nodes_base64

--- a/nodes.tf
+++ b/nodes.tf
@@ -9,7 +9,7 @@ resource "aws_instance" "nodes" {
   monitoring                  = var.nodes_monitoring
 
   subnet_id              = var.subnet_id
-  vpc_security_groups_ids = concat(
+  vpc_security_group_ids = concat(
     [aws_security_group.loadtest.id],  # Default security group ID
     var.additional_security_groups != null ? var.additional_security_groups : []
   )

--- a/scripts/entrypoint.leader.full.sh.tpl
+++ b/scripts/entrypoint.leader.full.sh.tpl
@@ -14,7 +14,7 @@ export BZT_VERSION="1.16.0"
 sudo pip3 install bzt==$BZT_VERSION
 
 # LOCUST
-export LOCUST_VERSION="2.9.0"
+export LOCUST_VERSION="2.29.0"
 sudo pip3 uninstall urllib3
 sudo pip3 install urllib3==1.26.6
 sudo pip3 install locust==$LOCUST_VERSION

--- a/scripts/entrypoint.leader.full.sh.tpl
+++ b/scripts/entrypoint.leader.full.sh.tpl
@@ -15,6 +15,8 @@ sudo pip3 install bzt==$BZT_VERSION
 
 # LOCUST
 export LOCUST_VERSION="2.9.0"
+sudo pip3 uninstall urllib3
+sudo pip3 install urllib3==1.26.6
 sudo pip3 install locust==$LOCUST_VERSION
 
 # JMETER

--- a/scripts/entrypoint.node.full.sh.tpl
+++ b/scripts/entrypoint.node.full.sh.tpl
@@ -8,7 +8,7 @@ export BZT_VERSION="1.16.0"
 sudo pip3 install bzt==$BZT_VERSION
 
 # LOCUST
-export LOCUST_VERSION="2.9.0"
+export LOCUST_VERSION="2.29.0"
 sudo pip3 uninstall urllib3
 sudo pip3 install urllib3==1.26.6
 sudo pip3 install locust==$LOCUST_VERSION

--- a/scripts/entrypoint.node.full.sh.tpl
+++ b/scripts/entrypoint.node.full.sh.tpl
@@ -9,8 +9,9 @@ sudo pip3 install bzt==$BZT_VERSION
 
 # LOCUST
 export LOCUST_VERSION="2.9.0"
+sudo pip3 uninstall urllib3
+sudo pip3 install urllib3==1.26.6
 sudo pip3 install locust==$LOCUST_VERSION
-
 
 # JMETER
 export MIRROR_HOST=https://archive.apache.org/dist/jmeter

--- a/scripts/locust.entrypoint.leader.full.sh.tpl
+++ b/scripts/locust.entrypoint.leader.full.sh.tpl
@@ -4,7 +4,7 @@ sudo yum update -y
 sudo yum install -y pcre2-devel.x86_64 python gcc python3-devel tzdata curl unzip bash htop
 
 # LOCUST
-export LOCUST_VERSION="2.9.0"
+export LOCUST_VERSION="2.29.0"
 sudo pip3 uninstall urllib3
 sudo pip3 install urllib3==1.26.6
 sudo pip3 install locust_plugins

--- a/scripts/locust.entrypoint.leader.full.sh.tpl
+++ b/scripts/locust.entrypoint.leader.full.sh.tpl
@@ -1,14 +1,24 @@
 #!/bin/bash
 
-sudo yum update -y
-sudo yum install -y pcre2-devel.x86_64 python gcc python3-devel tzdata curl unzip bash htop
+sudo dnf update -y
+sudo dnf install -y --allowerasing pcre2-devel.x86_64 python3.11 gcc python3.11-devel tzdata unzip bash htop python3.11-pip
+sudo dnf remove -y python3-requests
+
+# Set up alternatives to use Python 3.11 by default
+sudo alternatives --install /usr/bin/python3 python3 /usr/bin/python3.9 1
+sudo alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 2
+echo "2" | sudo alternatives --config python3
+
+# Set up alternatives to use pip3 for Python 3.11 by default
+sudo alternatives --install /usr/bin/pip3 pip3 /usr/bin/pip3.9 1
+sudo alternatives --install /usr/bin/pip3 pip3 /usr/bin/pip3.11 2
+echo "2" | sudo alternatives --config pip3
+
+sudo pip3 install requests
 
 # LOCUST
 export LOCUST_VERSION="2.29.0"
-sudo pip3 uninstall urllib3
-sudo pip3 install urllib3==1.26.6
-sudo pip3 install locust_plugins
-sudo pip3 install locust==$LOCUST_VERSION
+sudo pip3 install locust==$LOCUST_VERSION --log pip_install.log
 
 export PRIVATE_IP=$(hostname -I | awk '{print $1}')
 echo "PRIVATE_IP=$PRIVATE_IP" >> /etc/environment
@@ -18,6 +28,9 @@ source ~/.bashrc
 mkdir -p ~/.ssh
 echo 'Host *' > ~/.ssh/config
 echo 'StrictHostKeyChecking no' >> ~/.ssh/config
+
+sudo pip3 install "urllib3<2.0"
+sudo pip3 install locust_plugins
 
 sudo iptables -A INPUT -i eth0 -p tcp --dport 80 -j ACCEPT
 sudo iptables -A INPUT -i eth0 -p tcp --dport 8080 -j ACCEPT

--- a/scripts/locust.entrypoint.leader.full.sh.tpl
+++ b/scripts/locust.entrypoint.leader.full.sh.tpl
@@ -7,6 +7,7 @@ sudo yum install -y pcre2-devel.x86_64 python gcc python3-devel tzdata curl unzi
 export LOCUST_VERSION="2.9.0"
 sudo pip3 uninstall urllib3
 sudo pip3 install urllib3==1.26.6
+sudo pip3 install locust_plugins
 sudo pip3 install locust==$LOCUST_VERSION
 
 export PRIVATE_IP=$(hostname -I | awk '{print $1}')

--- a/scripts/locust.entrypoint.leader.full.sh.tpl
+++ b/scripts/locust.entrypoint.leader.full.sh.tpl
@@ -5,6 +5,8 @@ sudo yum install -y pcre2-devel.x86_64 python gcc python3-devel tzdata curl unzi
 
 # LOCUST
 export LOCUST_VERSION="2.9.0"
+sudo pip3 uninstall urllib3
+sudo pip3 install urllib3==1.26.6
 sudo pip3 install locust==$LOCUST_VERSION
 
 export PRIVATE_IP=$(hostname -I | awk '{print $1}')

--- a/scripts/locust.entrypoint.node.full.sh.tpl
+++ b/scripts/locust.entrypoint.node.full.sh.tpl
@@ -4,7 +4,7 @@ sudo yum update -y
 sudo yum install -y pcre2-devel.x86_64 python gcc python3-devel tzdata curl unzip bash htop
 
 # LOCUST
-export LOCUST_VERSION="2.9.0"
+export LOCUST_VERSION="2.29.0"
 sudo pip3 uninstall urllib3
 sudo pip3 install urllib3==1.26.6
 sudo pip3 install locust_plugins

--- a/scripts/locust.entrypoint.node.full.sh.tpl
+++ b/scripts/locust.entrypoint.node.full.sh.tpl
@@ -1,14 +1,27 @@
 #!/bin/bash
 
-sudo yum update -y
-sudo yum install -y pcre2-devel.x86_64 python gcc python3-devel tzdata curl unzip bash htop
+sudo dnf update -y
+sudo dnf install -y --allowerasing pcre2-devel.x86_64 python3.11 gcc python3.11-devel tzdata unzip bash htop python3.11-pip
+sudo dnf remove -y python3-requests
+
+# Set up alternatives to use Python 3.11 by default
+sudo alternatives --install /usr/bin/python3 python3 /usr/bin/python3.9 1
+sudo alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 2
+echo "2" | sudo alternatives --config python3
+
+# Set up alternatives to use pip3 for Python 3.11 by default
+sudo alternatives --install /usr/bin/pip3 pip3 /usr/bin/pip3.9 1
+sudo alternatives --install /usr/bin/pip3 pip3 /usr/bin/pip3.11 2
+echo "2" | sudo alternatives --config pip3
+
+sudo pip3 install requests
 
 # LOCUST
 export LOCUST_VERSION="2.29.0"
-sudo pip3 uninstall urllib3
-sudo pip3 install urllib3==1.26.6
-sudo pip3 install locust_plugins
-sudo pip3 install locust==$LOCUST_VERSION
+sudo pip3 install locust==$LOCUST_VERSION --log pip_install.log
+sudo pip3 uninstall urllib3 --log pip_install.log
+sudo pip3 install urllib3==1.26.6 --log pip_install.log
+sudo pip3 install locust_plugins --log pip_install.log
 
 export PRIVATE_IP=$(hostname -I | awk '{print $1}')
 echo "PRIVATE_IP=$PRIVATE_IP" >> /etc/environment

--- a/scripts/locust.entrypoint.node.full.sh.tpl
+++ b/scripts/locust.entrypoint.node.full.sh.tpl
@@ -7,6 +7,7 @@ sudo yum install -y pcre2-devel.x86_64 python gcc python3-devel tzdata curl unzi
 export LOCUST_VERSION="2.9.0"
 sudo pip3 uninstall urllib3
 sudo pip3 install urllib3==1.26.6
+sudo pip3 install locust_plugins
 sudo pip3 install locust==$LOCUST_VERSION
 
 export PRIVATE_IP=$(hostname -I | awk '{print $1}')

--- a/scripts/locust.entrypoint.node.full.sh.tpl
+++ b/scripts/locust.entrypoint.node.full.sh.tpl
@@ -5,6 +5,8 @@ sudo yum install -y pcre2-devel.x86_64 python gcc python3-devel tzdata curl unzi
 
 # LOCUST
 export LOCUST_VERSION="2.9.0"
+sudo pip3 uninstall urllib3
+sudo pip3 install urllib3==1.26.6
 sudo pip3 install locust==$LOCUST_VERSION
 
 export PRIVATE_IP=$(hostname -I | awk '{print $1}')

--- a/variables.tf
+++ b/variables.tf
@@ -236,3 +236,9 @@ variable "locust_exporter" {
   }
   description = "Export locust result to prometheus"
 }
+
+variable "additional_security_groups" {
+  description = "Additional security groups to attach"
+  type        = list(string)
+  default     = []
+}


### PR DESCRIPTION
Some sending multipart requests (required for loom write testing) is only supported in the latest version of locust, which requires python3.10 minimum. This isn't available on AWS Linux 2, so I upgraded to AL2023, and forced the install of python 3.11, then set  this as the alternative.